### PR TITLE
Allow multi-doc yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       - id: check-vcs-permalinks
       - id: check-xml
       - id: check-yaml
+        args: [--allow-multiple-documents]
         exclude: "templates/.*"
       - id: mixed-line-ending
       #      - id: trailing-whitespace


### PR DESCRIPTION
* Example of a valid partner use case:
  https://github.com/aws-quickstart/quickstart-vmware-tanzu-application-platform/blob/08be3e6ef8f6cc3e0298d7eade4c68a8a0e517ef/tap-setup-scripts/src/resources/developer-namespace.yaml
* Reference:
  https://github.com/pre-commit/pre-commit-hooks#check-yaml