### PR TITLE
Update TFLint aws plugin to 0.17.0

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -3,7 +3,7 @@
 
 plugin "aws" {
     enabled = true
-    version = "0.15.0"
+    version = "0.17.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 


### PR DESCRIPTION
The goal of this PR is to update TFLint's aws plugin to 0.17.0.